### PR TITLE
Set caching to crisp before calling AddIsEqualForObjects

### DIFF
--- a/gap/PositivelyZGradedCategory.gi
+++ b/gap/PositivelyZGradedCategory.gi
@@ -847,10 +847,10 @@ InstallMethod( PositivelyZGradedCategory,
     AddObjectRepresentation( ZC, IsObjectInPositivelyZGradedCategory );
     AddMorphismRepresentation( ZC, IsMorphismInPositivelyZGradedCategory );
     
+    SetCachingOfCategoryCrisp( ZC );
+    
     AddIsEqualForObjects( ZC, IsIdenticalObj );
     AddIsEqualForMorphisms( ZC, IsIdenticalObj );
-    
-    SetCachingOfCategoryCrisp( ZC );
     
     if HasCommutativeRingOfLinearCategory( C ) then
         SetCommutativeRingOfLinearCategory( ZC, CommutativeRingOfLinearCategory( C ) );


### PR DESCRIPTION
This prevents a warning with CAP PR #447.