### PR TITLE
Skip DirectSumDiagonalDifference

### DIFF
--- a/gap/PositivelyZGradedCategory.gi
+++ b/gap/PositivelyZGradedCategory.gi
@@ -1008,7 +1008,8 @@ InstallMethod( PositivelyZGradedCategory,
     skip := [ "MultiplyWithElementOfCommutativeRingForMorphisms",
               "Lift",
               "Colift",
-              "FiberProductEmbeddingInDirectSum", ## TOOD: CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS in create_func_morphism cannot deal with it yet
+              "FiberProductEmbeddingInDirectSum", ## TODO: CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS in create_func_morphism cannot deal with it yet
+              "DirectSumDiagonalDifference", ## TODO: CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS in create_func_morphism cannot deal with it yet
               ];
     
     for func in skip do


### PR DESCRIPTION
It seems like CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS cannot deal
with it yet.

This was uncovered by an error in `InternalModules` after the merge of https://github.com/homalg-project/CAP_project/pull/492: this PR leads to different weights of derived With(out)Given methods so different derivations are triggered.

Note: I assume this also affects `CategoryConstructor`: https://github.com/homalg-project/CategoryConstructor/blob/0fab8e9b858c4b687cc9489f73aa96b690a8923f/gap/CategoryConstructor.gi#L50
